### PR TITLE
Fix the environment variable name for POSTGRES_DBNAME

### DIFF
--- a/llama-stack/helm/values.yaml
+++ b/llama-stack/helm/values.yaml
@@ -64,7 +64,7 @@ env:
       secretKeyRef:
         key: port
         name: pgvector
-  - name: PGVECTOR_DBNAME
+  - name: POSTGRES_DBNAME
     valueFrom:
       secretKeyRef:
         key: dbname


### PR DESCRIPTION
The environment variable name was mentioned as PGVECTOR_DBNAME and in the run_config it was referring as POSTGRES_DBNAME