### PR TITLE
fix: use token if needed when waiting for models

### DIFF
--- a/llama-stack/helm/templates/deployment.yaml
+++ b/llama-stack/helm/templates/deployment.yaml
@@ -43,9 +43,16 @@ spec:
             - -c
             - |
               set -e
-              for url in {{ range $key, $model := $models }}{{- if $model.enabled }}{{ $model.url }}/models {{ end }}{{ end }}; do
+              for url_data in {{ range $key, $model := $models }}{{- if $model.enabled }}{{ $model.url }}/models#{{ $model.apiToken }}{{ end }}{{ end }}; do
                 echo "Waiting for $url..."
-                until curl -ksf "$url"; do
+                url_components=(${url_data//#/ })
+                url=${url_components[0]}
+                auth=${url_components[1]}
+                curl_options=("-ksf" "$url")
+                if [[ -n "$auth" ]]; then
+                  curl_options+=("-H" "Authorization: Bearer $auth")
+                fi
+                until curl "${curl_options[@]}"; do
                   echo "Still waiting for $url ..."
                   sleep 10
                 done


### PR DESCRIPTION
If provided use the token provided for a model when checking if is available. Otherwise the check fails