### PR TITLE
Add llama-3-2-3b-instruct-fp16 model to LLM service

### DIFF
--- a/llm-service/helm/values.yaml
+++ b/llm-service/helm/values.yaml
@@ -76,6 +76,25 @@ models:
       - --max-model-len
       - "30544"
 
+  llama-3-2-3b-instruct-fp16:
+    id: llama3.2:3b-instruct-fp16
+    enabled: true
+    metadata:
+      provider: ollama
+      size: "3B"
+      precision: "fp16"
+      description: "Llama 3.2 3B model with fp16 precision for runtime compatibility"
+    args:
+      - --enable-auto-tool-choice
+      - --chat-template
+      - /chat-templates/tool_chat_template_llama3.2_json.jinja
+      - --tool-call-parser
+      - llama3_json
+      - --max-model-len
+      - "30544"
+      - --gpu-memory-utilization
+      - "0.8"
+
   llama-guard-3-8b:
     id: meta-llama/Llama-Guard-3-8B
     enabled: false


### PR DESCRIPTION
- Added new model configuration with Ollama provider
- Model ID: llama3.2:3b-instruct-fp16 (fp16 precision for runtime compatibility)