### PR TITLE
llm-service: add Qwen/Qwen2.5-VL-3B-Instruct model

### DIFF
--- a/llm-service/helm/files/tool_chat_template_qwen.jinja
+++ b/llm-service/helm/files/tool_chat_template_qwen.jinja
@@ -1,0 +1,40 @@
+{%- set image_count = namespace(value=0) -%}
+{%- set video_count = namespace(value=0) -%}
+{%- for message in messages -%}
+	{%- if loop.first and message["role"] != "system" -%}
+		{{- "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n" -}}
+	{%- endif -%}
+	{{- "<|im_start|>" -}}
+	{{- message["role"] -}}
+	{{- "\n" -}}
+	{%- if message["content"] is string -%}
+		{{- message["content"] -}}
+		{{- "<|im_end|>\n" -}}
+	{%- else -%}
+		{%- for content in message["content"] -%}
+			{%- if content["type"] == "image" or "image" in content or "image_url" in content -%}
+				{%- set image_count.value = image_count.value + 1 -%}
+				{%- if add_vision_id -%}
+					{{- "Picture " -}}
+					{{- image_count.value -}}
+					{{- ": " -}}
+				{%- endif -%}
+				{{- "<|vision_start|><|image_pad|><|vision_end|>" -}}
+			{%- elif content["type"] == "video" or "video" in content -%}
+				{%- set video_count.value = video_count.value + 1 -%}
+				{%- if add_vision_id -%}
+					{{- "Video " -}}
+					{{- video_count.value -}}
+					{{- ": " -}}
+				{%- endif -%}
+				{{- "<|vision_start|><|video_pad|><|vision_end|>" -}}
+			{%- elif "text" in content -%}
+				{{- content["text"] -}}
+			{%- endif -%}
+		{%- endfor -%}
+		{{- "<|im_end|>\n" -}}
+	{%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+	{{- "<|im_start|>assistant\n" -}}
+{%- endif -%}

--- a/llm-service/helm/templates/configmap.yaml
+++ b/llm-service/helm/templates/configmap.yaml
@@ -7,3 +7,5 @@ data:
 {{ .Files.Get "files/tool_chat_template_llama3.2_json.jinja" | indent 4 }}
   tool_chat_template_llama3.2_pythonic.jinja: |-
 {{ .Files.Get "files/tool_chat_template_llama3.2_pythonic.jinja" | indent 4 }}
+  tool_chat_template_qwen.jinja: |-
+{{ .Files.Get "files/tool_chat_template_qwen.jinja" | indent 4 }}

--- a/llm-service/helm/values.yaml
+++ b/llm-service/helm/values.yaml
@@ -137,3 +137,14 @@ models:
       - llama3_json
       - --max-model-len
       - "30544"
+
+  qwen-2-5-vl-3b-instruct:
+    id: Qwen/Qwen2.5-VL-3B-Instruct
+    args:
+      - --max-model-len
+      - "30544"
+      - --enable-auto-tool-choice
+      - --chat-template
+      - /chat-templates/tool_chat_template_qwen.jinja
+      - --tool-call-parser
+      - llama3_json


### PR DESCRIPTION
This change adds the `Qwen/Qwen2.5-VL-3B-Instruct` model in `llm-service` which is capable of visual processing (e.g. handling picture attachments in virtual agent).